### PR TITLE
ユーザー登録・ログイン機能の実装

### DIFF
--- a/src/public/complete.php
+++ b/src/public/complete.php
@@ -1,4 +1,10 @@
 <?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit();
+}
+
 $title = $_POST['title'] ?? '';
 $email = $_POST['email'] ?? '';
 $content = $_POST['content'] ?? '';
@@ -20,6 +26,7 @@ if (empty($title) || empty($email) || empty($content)) {
     echo '<h1>送信完了！！！</h1>';
     echo '<br><a href="index.php">送信画面へ</a><br>';
     echo '<a href="history.php">送信履歴へ</a>';
+    echo '<a href="logout.php">ログアウト</a>';
 
     // データベースに接続
     $dbUserName = 'root';

--- a/src/public/history.php
+++ b/src/public/history.php
@@ -1,4 +1,10 @@
 <?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit();
+}
+
 // データベースに接続
 $dbUserName = 'root';
 $dbPassword = 'password';
@@ -44,5 +50,6 @@ $contacts = $stmt->fetchAll(PDO::FETCH_ASSOC);
     <?php endif; ?>
     <br>
     <a href="index.php">送信画面へ戻る</a>
+    <a href="logout.php">ログアウト</a>
 </body>
 </html>

--- a/src/public/index.php
+++ b/src/public/index.php
@@ -1,3 +1,9 @@
 <?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
 readfile('regist.html');
 ?>

--- a/src/public/login.php
+++ b/src/public/login.php
@@ -31,6 +31,9 @@ session_start(); ?>
                 ログイン
             </button>
         </form>
+        <p class="mt-4 text-center">
+            アカウントをお持ちでない方は<a href="register.php" class="text-indigo-500 hover:underline">こちら</a>から登録してください。
+        </p>
     </div>
 </body>
 </html>

--- a/src/public/login.php
+++ b/src/public/login.php
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html lang="ja">
 <head>
@@ -12,8 +11,8 @@
         <h1 class="text-2xl font-bold mb-4">ログイン</h1>
         <form action="login_process.php" method="post">
             <div class="mb-4">
-                <label for="username" class="block text-sm font-medium text-gray-700 mb-1">ユーザー名</label>
-                <input type="text" id="username" name="username" class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                <label for="username_email" class="block text-sm font-medium text-gray-700 mb-1">ユーザー名またはメールアドレス</label>
+                <input type="text" id="username_email" name="username_email" class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
             </div>
             <div class="mb-4">
                 <label for="password" class="block text-sm font-medium text-gray-700 mb-1">パスワード</label>

--- a/src/public/login.php
+++ b/src/public/login.php
@@ -1,0 +1,28 @@
+
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ログイン</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 flex justify-center items-center min-h-screen p-4">
+    <div class="bg-white rounded-lg shadow-md p-8 max-w-md w-full">
+        <h1 class="text-2xl font-bold mb-4">ログイン</h1>
+        <form action="login_process.php" method="post">
+            <div class="mb-4">
+                <label for="username" class="block text-sm font-medium text-gray-700 mb-1">ユーザー名</label>
+                <input type="text" id="username" name="username" class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
+            </div>
+            <div class="mb-4">
+                <label for="password" class="block text-sm font-medium text-gray-700 mb-1">パスワード</label>
+                <input type="password" id="password" name="password" class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
+            </div>
+            <button type="submit" class="w-full bg-indigo-500 text-white py-2 px-4 rounded-md hover:bg-indigo-600 transition duration-300">
+                ログイン
+            </button>
+        </form>
+    </div>
+</body>
+</html>

--- a/src/public/login.php
+++ b/src/public/login.php
@@ -1,3 +1,6 @@
+<?php
+session_start(); ?>
+
 <!DOCTYPE html>
 <html lang="ja">
 <head>
@@ -9,6 +12,12 @@
 <body class="bg-gray-100 flex justify-center items-center min-h-screen p-4">
     <div class="bg-white rounded-lg shadow-md p-8 max-w-md w-full">
         <h1 class="text-2xl font-bold mb-4">ログイン</h1>
+        <?php if (isset($_SESSION['login_error'])) {
+            echo '<p class="text-red-500 mb-4">' .
+                htmlspecialchars($_SESSION['login_error']) .
+                '</p>';
+            unset($_SESSION['login_error']);
+        } ?>
         <form action="login_process.php" method="post">
             <div class="mb-4">
                 <label for="username_email" class="block text-sm font-medium text-gray-700 mb-1">ユーザー名またはメールアドレス</label>

--- a/src/public/login_process.php
+++ b/src/public/login_process.php
@@ -5,7 +5,9 @@ $username_email = $_POST['username_email'] ?? '';
 $password = $_POST['password'] ?? '';
 
 if (empty($username_email) || empty($password)) {
-    echo 'ユーザー名/メールアドレスとパスワードを入力してください。';
+    $_SESSION['login_error'] =
+        'ユーザー名/メールアドレスとパスワードを入力してください。';
+    header('Location: login.php');
     exit();
 }
 
@@ -30,6 +32,7 @@ if ($user && password_verify($password, $user['password'])) {
     header('Location: index.php');
     exit();
 } else {
-    echo 'ユーザー名またはパスワードが間違っています。';
+    $_SESSION['login_error'] = 'ユーザー名またはパスワードが間違っています。';
+    header('Location: login.php');
     exit();
 }

--- a/src/public/login_process.php
+++ b/src/public/login_process.php
@@ -1,0 +1,33 @@
+<?php
+session_start();
+
+$username = $_POST['username'] ?? '';
+$password = $_POST['password'] ?? '';
+
+if (empty($username) || empty($password)) {
+    echo 'ユーザー名とパスワードを入力してください。';
+    exit();
+}
+
+$dbUserName = 'root';
+$dbPassword = 'password';
+$pdo = new PDO(
+    'mysql:host=mysql; dbname=contactform; charset=utf8mb4',
+    $dbUserName,
+    $dbPassword
+);
+
+$stmt = $pdo->prepare('SELECT * FROM users WHERE username = :username');
+$stmt->bindParam(':username', $username, PDO::PARAM_STR);
+$stmt->execute();
+$user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if ($user && password_verify($password, $user['password'])) {
+    $_SESSION['user_id'] = $user['id'];
+    $_SESSION['username'] = $user['username'];
+    header('Location: index.php');
+    exit();
+} else {
+    echo 'ユーザー名またはパスワードが間違っています。';
+    exit();
+}

--- a/src/public/login_process.php
+++ b/src/public/login_process.php
@@ -1,11 +1,11 @@
 <?php
 session_start();
 
-$username = $_POST['username'] ?? '';
+$username_email = $_POST['username_email'] ?? '';
 $password = $_POST['password'] ?? '';
 
-if (empty($username) || empty($password)) {
-    echo 'ユーザー名とパスワードを入力してください。';
+if (empty($username_email) || empty($password)) {
+    echo 'ユーザー名/メールアドレスとパスワードを入力してください。';
     exit();
 }
 
@@ -17,8 +17,10 @@ $pdo = new PDO(
     $dbPassword
 );
 
-$stmt = $pdo->prepare('SELECT * FROM users WHERE username = :username');
-$stmt->bindParam(':username', $username, PDO::PARAM_STR);
+$stmt = $pdo->prepare(
+    'SELECT * FROM users WHERE username = :username_email OR email = :username_email'
+);
+$stmt->bindParam(':username_email', $username_email, PDO::PARAM_STR);
 $stmt->execute();
 $user = $stmt->fetch(PDO::FETCH_ASSOC);
 

--- a/src/public/logout.php
+++ b/src/public/logout.php
@@ -1,0 +1,5 @@
+<?php
+session_start();
+session_destroy();
+header('Location: login.php');
+exit();

--- a/src/public/regist.html
+++ b/src/public/regist.html
@@ -51,12 +51,17 @@
         </div>
         <button
           type="submit"
-          class="w-full bg-indigo-500 text-white py-2 px-4 rounded-md hover:bg-indigo-600 transition duration-300"
+          class="w-full bg-indigo-500 text-white py-2 px-4 rounded-md hover:bg-indigo-600 transition duration-300 mb-4"
         >
           送信
         </button>
       </form>
-      <a href="logout.php">ログアウト</a>
+      <a
+        href="logout.php"
+        class="block w-full bg-indigo-500 text-white py-2 px-4 rounded-md hover:bg-indigo-600 transition duration-300 text-center"
+      >
+        ログアウト
+      </a>
     </div>
   </body>
 </html>

--- a/src/public/regist.html
+++ b/src/public/regist.html
@@ -4,28 +4,58 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>お問い合わせフォーム</title>
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
-  <body>
-    <h1>お問い合わせフォーム</h1>
-    <p>以下のフォームに必要事項をご記入の上、送信ボタンを押してください。</p>
-    <form action="complete.php" method="post">
-      <div>
-        <label for="title">タイトル（必須）：</label>
-        <input type="text" id="title" name="title" placeholder="タイトル" />
-      </div>
-      <div>
-        <label for="email">Email：</label>
-        <input type="email" id="email" name="email" placeholder="Email" />
-      </div>
-      <div>
-        <label for="content">お問合せ内容：</label>
-        <textarea
-          id="content"
-          name="content"
-          placeholder="お問合せ内容(1000文字まで)をお書きください。"
-        ></textarea>
-      </div>
-      <button type="submit">送信</button>
-    </form>
+  <body class="bg-gray-100 flex justify-center items-center min-h-screen p-4">
+    <div class="bg-white rounded-lg shadow-md p-8 max-w-md w-full">
+      <h1 class="text-2xl font-bold mb-4">お問い合わせフォーム</h1>
+      <form action="complete.php" method="post">
+        <div class="mb-4">
+          <label
+            for="title"
+            class="block text-sm font-medium text-gray-700 mb-1"
+            >タイトル（必須）</label
+          >
+          <input
+            type="text"
+            id="title"
+            name="title"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+        <div class="mb-4">
+          <label
+            for="email"
+            class="block text-sm font-medium text-gray-700 mb-1"
+            >Email</label
+          >
+          <input
+            type="email"
+            id="email"
+            name="email"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+        <div class="mb-4">
+          <label
+            for="content"
+            class="block text-sm font-medium text-gray-700 mb-1"
+            >お問合せ内容</label
+          >
+          <textarea
+            id="content"
+            name="content"
+            rows="4"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          ></textarea>
+        </div>
+        <button
+          type="submit"
+          class="w-full bg-indigo-500 text-white py-2 px-4 rounded-md hover:bg-indigo-600 transition duration-300"
+        >
+          送信
+        </button>
+      </form>
+    </div>
   </body>
 </html>

--- a/src/public/regist.html
+++ b/src/public/regist.html
@@ -56,6 +56,7 @@
           送信
         </button>
       </form>
+      <a href="logout.php">ログアウト</a>
     </div>
   </body>
 </html>

--- a/src/public/register.php
+++ b/src/public/register.php
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ユーザー登録</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 flex justify-center items-center min-h-screen p-4">
+    <div class="bg-white rounded-lg shadow-md p-8 max-w-md w-full">
+        <h1 class="text-2xl font-bold mb-4">ユーザー登録</h1>
+        <form action="register_process.php" method="post">
+            <div class="mb-4">
+                <label for="username" class="block text-sm font-medium text-gray-700 mb-1">ユーザー名</label>
+                <input type="text" id="username" name="username" required class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
+            </div>
+            <div class="mb-4">
+                <label for="email" class="block text-sm font-medium text-gray-700 mb-1">メールアドレス</label>
+                <input type="email" id="email" name="email" required class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
+            </div>
+            <div class="mb-4">
+                <label for="password" class="block text-sm font-medium text-gray-700 mb-1">パスワード</label>
+                <input type="password" id="password" name="password" required class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
+            </div>
+            <button type="submit" class="w-full bg-indigo-500 text-white py-2 px-4 rounded-md hover:bg-indigo-600 transition duration-300">
+                登録
+            </button>
+        </form>
+        <p class="mt-4 text-center">
+            既にアカウントをお持ちの方は<a href="login.php" class="text-indigo-500 hover:underline">こちら</a>からログインしてください。
+        </p>
+    </div>
+</body>
+</html>

--- a/src/public/register_process.php
+++ b/src/public/register_process.php
@@ -1,0 +1,57 @@
+<?php
+session_start();
+
+$username = $_POST['username'] ?? '';
+$email = $_POST['email'] ?? '';
+$password = $_POST['password'] ?? '';
+
+if (empty($username) || empty($email) || empty($password)) {
+    $_SESSION['error'] = '全ての項目を入力してください。';
+    header('Location: register.php');
+    exit();
+}
+
+// データベースに接続
+$dbUserName = 'root';
+$dbPassword = 'password';
+$pdo = new PDO(
+    'mysql:host=mysql; dbname=contactform; charset=utf8mb4',
+    $dbUserName,
+    $dbPassword
+);
+
+// ユーザー名またはメールアドレスが既に存在するか確認
+$stmt = $pdo->prepare(
+    'SELECT * FROM users WHERE username = :username OR email = :email'
+);
+$stmt->bindParam(':username', $username, PDO::PARAM_STR);
+$stmt->bindParam(':email', $email, PDO::PARAM_STR);
+$stmt->execute();
+
+if ($stmt->rowCount() > 0) {
+    $_SESSION['error'] =
+        'ユーザー名またはメールアドレスが既に使用されています。';
+    header('Location: register.php');
+    exit();
+}
+
+// パスワードをハッシュ化
+$hashedPassword = password_hash($password, PASSWORD_DEFAULT);
+
+// ユーザー情報をデータベースに保存
+$stmt = $pdo->prepare(
+    'INSERT INTO users (username, email, password) VALUES (:username, :email, :password)'
+);
+$stmt->bindParam(':username', $username);
+$stmt->bindParam(':email', $email);
+$stmt->bindParam(':password', $hashedPassword);
+$stmt->execute();
+
+if ($stmt->execute()) {
+    $_SESSION['success'] = 'ユーザー登録が完了しました。ログインしてください。';
+    header('Location: login.php');
+} else {
+    $_SESSION['error'] = 'ユーザー登録に失敗しました。もう一度お試しください。';
+    header('Location: register.php');
+}
+exit();


### PR DESCRIPTION
### ログイン機能
- ユーザー名もしくはメールアドレスとパスワードを使用してログイン機能を実装
- ログインに失敗した際に、ページ遷移せずにその場でエラーメッセージが出るように変更

<img width="1029" alt="スクリーンショット 2024-09-21 15 05 24" src="https://github.com/user-attachments/assets/ffd0cce1-f3e1-44b6-9248-d88adf063990">
<img width="914" alt="スクリーンショット 2024-09-21 15 05 46" src="https://github.com/user-attachments/assets/de589163-740a-4ecc-931b-3c3c88aec755">


### ユーザー登録
- ユーザー名・メールアドレス・パスワードの3つの項目でユーザー登録を実装

<img width="1428" alt="スクリーンショット 2024-09-21 15 04 37" src="https://github.com/user-attachments/assets/9c420f4d-4783-41d3-b966-e881049f290d">
